### PR TITLE
Implement HTTP server for CWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# servedir
+
+Simple HTTP server inspired by `python -mSimpleHTTPServer`.
+
+Serves files in current working directory on next free port:
+
+Run it as
+
+    > go run foxygo.at/servedir
+    Starting HTTP server at http://localhost:52537
+
+or get and run it with
+
+    > go get foxygo.at/servedir
+    > servedir
+    Starting HTTP server at http://localhost:52537

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module foxygo.at/servedir
+
+go 1.14

--- a/main.go
+++ b/main.go
@@ -1,0 +1,21 @@
+// servedir command start http server, serving files in current directory
+//       go run foxygo.at/servedir
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+)
+
+func main() {
+	http.Handle("/", http.FileServer(http.Dir(".")))
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Starting HTTP server on http://localhost:%d\n", listener.Addr().(*net.TCPAddr).Port)
+	log.Fatal(http.Serve(listener, nil))
+}


### PR DESCRIPTION
Implement simple HTTP server inspired by `python -mSimpleHTTPServer`.
Serve files in current working directory on next free port, on localhost.