### PR TITLE
flags: Take -a and -p from environment as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # --- Global -------------------------------------------------------------------
 O = out
-COVERAGE = 59
+COVERAGE = 66
 VERSION ?= $(shell git describe --tags --dirty  --always)
 
 all: build test check-coverage lint ## build, test, check coverage and lint

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # --- Global -------------------------------------------------------------------
 O = out
-COVERAGE = 60
+COVERAGE = 59
 VERSION ?= $(shell git describe --tags --dirty  --always)
 
 all: build test check-coverage lint ## build, test, check coverage and lint

--- a/main.go
+++ b/main.go
@@ -2,16 +2,15 @@
 // the current directory or a specified directory, on the next free
 // ephemeral port or a specified port.
 //
-//     go get foxygo.at/servedir
-//     servedir --help
-//     usage: servedir [-a] [-p <port>] [<dir>]
+//	go run foxygo.at/servedir@latest --help
+//	usage: servedir [-a] [-p <port>] [<dir>]
 //
-//     Simple HTTP server, serving files from given directory.
+//	Simple HTTP server, serving files from given directory.
 //
-//       -a	listen on all interfaces not just localhost
-//       -p int
-//            port number (default: os chosen free port)
-//       <dir> defaults to current directory if not specified
+//	  -a	listen on all interfaces not just localhost
+//	  -p int
+//	        port number (default: os chosen free port)
+//	  <dir> defaults to current directory if not specified
 package main
 
 import (
@@ -24,11 +23,11 @@ import (
 	"strings"
 )
 
-func usage() {
-	w := flag.CommandLine.Output()
+func usage(fs *flag.FlagSet) {
+	w := fs.Output()
 	fmt.Fprintf(w, "usage: %s [-a] [-p <port>] [<dir>]\n\n", os.Args[0])
 	fmt.Fprintf(w, "Simple HTTP server, serving files from given directory.\n\n")
-	flag.PrintDefaults()
+	fs.PrintDefaults()
 	fmt.Fprintf(w, "  <dir> defaults to current directory if not specified\n")
 }
 
@@ -67,19 +66,20 @@ type config struct {
 	listenAddr string
 }
 
-func parseFlags() config {
-	port := flag.Int("p", 0, "port number (default: os chosen free port)")
-	allInterfaces := flag.Bool("a", false, "listen on all interfaces not just localhost")
-	flag.Usage = usage
-	flag.Parse()
+func parseFlags(args ...string) config {
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	port := fs.Int("p", 0, "port number (default: os chosen free port)")
+	allInterfaces := fs.Bool("a", false, "listen on all interfaces not just localhost")
+	fs.Usage = func() { usage(fs) }
+	fs.Parse(args) //nolint:errcheck // ExitOnError means this does not return an error
 	return config{
-		dir:        dir(flag.Args()),
+		dir:        dir(fs.Args()),
 		listenAddr: listenAddr(*port, *allInterfaces),
 	}
 }
 
 func main() {
-	cfg := parseFlags()
+	cfg := parseFlags(os.Args[1:]...)
 	http.Handle("/", http.FileServer(http.Dir(cfg.dir)))
 	listener, err := net.Listen("tcp", cfg.listenAddr)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestUsage(t *testing.T) {
 	w := bytes.NewBuffer(nil)
-	flag.CommandLine.SetOutput(w)
-	usage()
+	fs := flag.NewFlagSet("servedir", flag.ExitOnError)
+	fs.SetOutput(w)
+	usage(fs)
 	opts := `[-a] [-p <port>] [<dir>]`
 	desc := `Simple HTTP server, serving files from given directory.`
 	require.Contains(t, w.String(), opts)

--- a/main_test.go
+++ b/main_test.go
@@ -61,3 +61,14 @@ func TestParseFlags(t *testing.T) {
 	got := parseFlags()
 	require.Equal(t, want, got)
 }
+
+func TestParseFlagsFromEnvironment(t *testing.T) {
+	want := config{
+		listenAddr: ":1",
+		dir:        ".",
+	}
+	t.Setenv("SERVEDIR_ALL_INTERFACES", "true")
+	t.Setenv("SERVEDIR_PORT", "1")
+	got := parseFlags()
+	require.Equal(t, want, got)
+}


### PR DESCRIPTION
Take the values for the flags `-a` and `-p` from environment variables
as the default, still allowing them to be overridden on the command
line.

Sometimes using `servedir`, you may always want to listen on all
interfaces but the default invocation of `servedir` in a Makefile recipe
does not specify `-a`. You can now set `SERVEDIR_ALL_INTERFACES=true` in
the environment and these pre-canned `servedir` invocations can work
with your defaults.

This switches the use of the `flag` package to use an explicit `FlagSet`
instead of using the global one in the `flag` package. Using the global
one makes it a lot harder to test as flags get redefined.
